### PR TITLE
feat: add textlint-ja image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+tests/__pycache__

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,18 @@
+services:
+  textlint-ja:
+    build:
+      context: textlint-ja
+  tests:
+    build:
+      context: tests
+    environment:
+      HOST_PWD: $PWD
+    volumes:
+      - type: bind
+        source: /var/run/docker.sock
+        target: /var/run/docker.sock
+      - type: bind
+        source: tests/
+        target: /home/tests/
+    working_dir: /home
+    entrypoint: ["python3", "-m", "pytest"]

--- a/data/tex/.textlintrc
+++ b/data/tex/.textlintrc
@@ -1,0 +1,10 @@
+{
+	"plugins": ["latex2e"],
+	"rules": {
+		"preset-ja-technical-writing": {
+			"ja-no-mixed-period": {
+				"periodMark": "。"
+			}
+		}
+	}
+}

--- a/data/tex/hello.tex
+++ b/data/tex/hello.tex
@@ -1,0 +1,9 @@
+\documentclass{ltjsarticle}
+
+\title{こんにちは}
+
+\begin{document}
+
+これは\LaTeX文書のサンプルです。
+
+\end{document}

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.9
+
+RUN pip install --upgrade pip && pip install docker pytest

--- a/tests/data/ja.md
+++ b/tests/data/ja.md
@@ -1,0 +1,3 @@
+# 日本語Markdown
+
+これは日本語で書かれたMarkdownです。

--- a/tests/test_textlint-ja.py
+++ b/tests/test_textlint-ja.py
@@ -1,0 +1,71 @@
+import docker
+from docker.types import Mount
+import os
+from pytest import fixture
+
+
+IMAGE_NAME='docker-images_textlint-ja'
+HOST_PWD=os.environ['HOST_PWD']
+
+
+@fixture
+def client():
+    return docker.from_env()
+
+
+@fixture
+def mount_test_dir():
+    return Mount(source=f'{HOST_PWD}/tests', target='/home/node/app', type='bind')
+
+
+@fixture
+def mount_data_tex_dir():
+    return Mount(source=f'{HOST_PWD}/data/tex', target='/home/node/app', type='bind')
+
+
+
+def test_with_no_input(client):
+    """何も入力を渡さないときに正常に終了することを確認する"""
+    container = client.containers.run(IMAGE_NAME, detach=True)
+
+    result = container.wait()
+    print(container.logs().decode())
+
+    container.remove()
+
+    assert result['StatusCode'] == 0
+
+
+def test_ls(client, mount_test_dir):
+    """lsコマンドを実行してマウント位置が正しいことを確認する"""
+    cnt = client.containers.run(IMAGE_NAME, ['-c', 'ls -a'], entrypoint='bash',
+            mounts=[mount_test_dir], remove=True)
+
+    file_list = cnt.decode().splitlines()
+
+    assert 'test_textlint-ja.py' in file_list
+
+
+def test_ja_md(client, mount_test_dir):
+    """Markdownファイルのlintができることを確認する"""
+    container = client.containers.run(IMAGE_NAME, ['--preset', 'preset-japanese', 'data/ja.md'], mounts=[mount_test_dir], detach=True)
+
+    result = container.wait()
+    print(container.logs().decode())
+
+    container.remove()
+
+    assert result['StatusCode'] == 0
+
+
+def test_latex_ja(client, mount_data_tex_dir):
+    """LaTeXファイルのlintができることを確認する"""
+    container = client.containers.run(IMAGE_NAME, '*.tex', mounts=[mount_data_tex_dir], detach=True)
+
+    result = container.wait()
+    output = container.logs().decode()
+
+    container.remove()
+
+    assert output == ''
+    assert result['StatusCode'] == 0

--- a/textlint-ja/Dockerfile
+++ b/textlint-ja/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:18
+
+USER node
+
+WORKDIR /home/node/textlint
+
+RUN npm init --yes
+RUN npm install --save-dev textlint textlint-rule-preset-japanese \
+      textlint-plugin-latex2e textlint-rule-preset-ja-technical-writing
+
+ENV FORCE_COLOR=1
+
+WORKDIR /home/node/app
+
+ENTRYPOINT ["/home/node/textlint/node_modules/.bin/textlint"]


### PR DESCRIPTION
textlintと日本語用のプリセットをインストールしたイメージを追加する。
`docker compose run --rm tests`でこのイメージに対するテストを実行できる。
