### PR TITLE
refactor: add pylint and yapf

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -17,6 +17,9 @@ services:
       - type: bind
         source: tests/
         target: /home/tests/
+      - type: bind # pylintにrcファイルを読み込ませるため
+        source: tests/pylintrc
+        target: /home/pylintrc
       - type: bind
         source: data/
         target: /home/data/

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,4 +21,4 @@ services:
         source: data/
         target: /home/data/
     working_dir: /home
-    entrypoint: ["python3", "-m", "pytest"]
+    entrypoint: ["python3"]

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
 FROM python:3.9
 
-RUN pip install --upgrade pip && \
-    pip install docker aiodocker pylint pytest pytest-asyncio
+RUN pip install --upgrade pip
+RUN pip install docker aiodocker pylint pylint-pytest pytest pytest-asyncio

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,3 +1,4 @@
 FROM python:3.9
 
-RUN pip install --upgrade pip && pip install docker aiodocker pytest pytest-asyncio
+RUN pip install --upgrade pip && \
+    pip install docker aiodocker pylint pytest pytest-asyncio

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
 FROM python:3.9
 
 RUN pip install --upgrade pip
-RUN pip install docker aiodocker pylint pylint-pytest pytest pytest-asyncio
+RUN pip install docker aiodocker pylint pylint-pytest pytest pytest-asyncio yapf

--- a/tests/pylintrc
+++ b/tests/pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+load-plugins=pylint_pytest

--- a/tests/test_cluttex.py
+++ b/tests/test_cluttex.py
@@ -16,7 +16,6 @@ from docker.types import Mount
 import pytest
 from pytest import fixture
 
-
 IMAGE_NAME: str = 'docker-images_cluttex'
 HOST_PWD: str = os.environ['HOST_PWD']
 
@@ -30,16 +29,16 @@ def client() -> docker.DockerClient:
 @fixture
 def mount_data_tex_dir() -> Mount:
     """data/texに対するマウントを作成する"""
-    return Mount(source=f'{HOST_PWD}/data/tex', target='/home/cluttex', type='bind')
+    return Mount(source=f'{HOST_PWD}/data/tex',
+                 target='/home/cluttex',
+                 type='bind')
 
 
 @contextmanager
-def run_container(
-        client: docker.DockerClient,
-        image: str,
-        command: Union[list[str], None] = None,
-        **kwargs
-) -> docker.models.containers.Container:
+def run_container(client: docker.DockerClient,
+                  image: str,
+                  command: Union[list[str], None] = None,
+                  **kwargs) -> docker.models.containers.Container:
     """
     Dockerイメージを実行してコンテナを返す。
     """
@@ -62,10 +61,10 @@ def test_with_no_input(client: docker.DockerClient):
 
 def test_ls(client: docker.DockerClient, mount_data_tex_dir: Mount):
     """lsコマンドを実行してマウント位置が正しいことを確認する"""
-    with run_container(
-            client, IMAGE_NAME,
-            entrypoint="bash -c 'ls -a'", mounts=[mount_data_tex_dir]
-            ) as container:
+    with run_container(client,
+                       IMAGE_NAME,
+                       entrypoint="bash -c 'ls -a'",
+                       mounts=[mount_data_tex_dir]) as container:
         result = container.wait()
         file_list = container.logs().decode().splitlines()
 
@@ -73,12 +72,12 @@ def test_ls(client: docker.DockerClient, mount_data_tex_dir: Mount):
     assert result['StatusCode'] == 0
 
 
-def test_compile_oneshot(client: docker.DockerClient, mount_data_tex_dir: Mount):
+def test_compile_oneshot(client: docker.DockerClient,
+                         mount_data_tex_dir: Mount):
     """一度だけコンパイルすることを確認する"""
-    with run_container(
-            client, IMAGE_NAME,
-            ["-e", "lualatex", "hello"], mounts=[mount_data_tex_dir]
-            ) as container:
+    with run_container(client,
+                       IMAGE_NAME, ["-e", "lualatex", "hello"],
+                       mounts=[mount_data_tex_dir]) as container:
         result = container.wait()
         logs = container.logs().decode()
 
@@ -87,7 +86,8 @@ def test_compile_oneshot(client: docker.DockerClient, mount_data_tex_dir: Mount)
 
 
 @asynccontextmanager
-async def run_cluttex_watch() -> AsyncIterator[aiodocker.docker.DockerContainer]:
+async def run_cluttex_watch(
+) -> AsyncIterator[aiodocker.docker.DockerContainer]:
     """
     `cluttex --watch -e lualatex hello`を実行するコンテナを起動する
 
@@ -100,16 +100,14 @@ async def run_cluttex_watch() -> AsyncIterator[aiodocker.docker.DockerContainer]
         'Cmd': ['--watch', '-e', 'lualatex', 'hello'],
         'User': 'root',
         'HostConfig': {
-            'Mounts': [
-                {
-                    "Type": "bind",
-                    "Source": f'{HOST_PWD}/data/test_compile_watch',
-                    "Target": "/home/cluttex",
-                    "Mode": "",
-                    "RW": True,
-                    "Propagation": "rprivate",
-                }
-            ]
+            'Mounts': [{
+                "Type": "bind",
+                "Source": f'{HOST_PWD}/data/test_compile_watch',
+                "Target": "/home/cluttex",
+                "Mode": "",
+                "RW": True,
+                "Propagation": "rprivate",
+            }]
         }
     }
     container = await docker.containers.run(config)
@@ -121,7 +119,8 @@ async def run_cluttex_watch() -> AsyncIterator[aiodocker.docker.DockerContainer]
         await docker.close()
 
 
-async def output_log_waiter(container: aiodocker.docker.DockerContainer) -> AsyncIterator[str]:
+async def output_log_waiter(
+        container: aiodocker.docker.DockerContainer) -> AsyncIterator[str]:
     """
     Output writtenのログ行を見つけたらその行をgenerateするasync generator
 

--- a/tests/test_cluttex.py
+++ b/tests/test_cluttex.py
@@ -1,32 +1,39 @@
 import asyncio
-import os
-import shutil
+from collections.abc import AsyncIterator
 from contextlib import contextmanager, asynccontextmanager
+import os
 from pathlib import Path
+import shutil
+from typing import Union
 
+import aiodocker
 import docker
 from docker.types import Mount
-import aiodocker
 import pytest
 from pytest import fixture
 
 
-IMAGE_NAME='docker-images_cluttex'
-HOST_PWD=os.environ['HOST_PWD']
+IMAGE_NAME: str = 'docker-images_cluttex'
+HOST_PWD: str = os.environ['HOST_PWD']
 
 
 @fixture
-def client():
+def client() -> docker.DockerClient:
     return docker.from_env()
 
 
 @fixture
-def mount_data_tex_dir():
+def mount_data_tex_dir() -> Mount:
     return Mount(source=f'{HOST_PWD}/data/tex', target='/home/cluttex', type='bind')
 
 
 @contextmanager
-def run_container(client, image, command=None, **kwargs):
+def run_container(
+        client: docker.DockerClient,
+        image: str,
+        command: Union[list[str], None] = None,
+        **kwargs
+) -> docker.models.containers.Container:
     container = client.containers.run(image, command, detach=True, **kwargs)
     try:
         yield container
@@ -34,7 +41,7 @@ def run_container(client, image, command=None, **kwargs):
         container.remove()
 
 
-def test_with_no_input(client):
+def test_with_no_input(client: docker.DockerClient):
     """何も入力を渡さないときにステータス1で終了することを確認する"""
     with run_container(client, IMAGE_NAME) as container:
         result = container.wait()
@@ -44,7 +51,7 @@ def test_with_no_input(client):
     assert result['StatusCode'] == 1
 
 
-def test_ls(client, mount_data_tex_dir):
+def test_ls(client: docker.DockerClient, mount_data_tex_dir: Mount):
     """lsコマンドを実行してマウント位置が正しいことを確認する"""
     with run_container(client, IMAGE_NAME, entrypoint="bash -c 'ls -a'", mounts=[mount_data_tex_dir]) as container:
         result = container.wait()
@@ -54,9 +61,9 @@ def test_ls(client, mount_data_tex_dir):
     assert result['StatusCode'] == 0
 
 
-def test_compile_oneshot(client, mount_data_tex_dir):
+def test_compile_oneshot(client: docker.DockerClient, mount_data_tex_dir: Mount):
     """一度だけコンパイルすることを確認する"""
-    with run_container(client, IMAGE_NAME, "-e lualatex hello", mounts=[mount_data_tex_dir]) as container:
+    with run_container(client, IMAGE_NAME, ["-e", "lualatex", "hello"], mounts=[mount_data_tex_dir]) as container:
         result = container.wait()
         logs = container.logs().decode()
 
@@ -65,7 +72,7 @@ def test_compile_oneshot(client, mount_data_tex_dir):
 
 
 @asynccontextmanager
-async def run_cluttex_watch():
+async def run_cluttex_watch() -> AsyncIterator[aiodocker.docker.DockerContainer]:
     """
     `cluttex --watch -e lualatex hello`を実行するコンテナを起動する
 
@@ -99,7 +106,7 @@ async def run_cluttex_watch():
         await docker.close()
 
 
-async def output_log_waiter(container):
+async def output_log_waiter(container: aiodocker.docker.DockerContainer) -> AsyncIterator[str]:
     """
     Output writtenのログ行を見つけたらその行をgenerateするasync generator
 

--- a/tests/test_cluttex.py
+++ b/tests/test_cluttex.py
@@ -1,3 +1,7 @@
+"""
+cluttexイメージをテストする。
+"""
+
 import asyncio
 from collections.abc import AsyncIterator
 from contextlib import contextmanager, asynccontextmanager
@@ -19,11 +23,13 @@ HOST_PWD: str = os.environ['HOST_PWD']
 
 @fixture
 def client() -> docker.DockerClient:
+    """Dockerのクライアントを作成するfixture"""
     return docker.from_env()
 
 
 @fixture
 def mount_data_tex_dir() -> Mount:
+    """data/texに対するマウントを作成する"""
     return Mount(source=f'{HOST_PWD}/data/tex', target='/home/cluttex', type='bind')
 
 
@@ -34,6 +40,9 @@ def run_container(
         command: Union[list[str], None] = None,
         **kwargs
 ) -> docker.models.containers.Container:
+    """
+    Dockerイメージを実行してコンテナを返す。
+    """
     container = client.containers.run(image, command, detach=True, **kwargs)
     try:
         yield container
@@ -53,7 +62,10 @@ def test_with_no_input(client: docker.DockerClient):
 
 def test_ls(client: docker.DockerClient, mount_data_tex_dir: Mount):
     """lsコマンドを実行してマウント位置が正しいことを確認する"""
-    with run_container(client, IMAGE_NAME, entrypoint="bash -c 'ls -a'", mounts=[mount_data_tex_dir]) as container:
+    with run_container(
+            client, IMAGE_NAME,
+            entrypoint="bash -c 'ls -a'", mounts=[mount_data_tex_dir]
+            ) as container:
         result = container.wait()
         file_list = container.logs().decode().splitlines()
 
@@ -63,7 +75,10 @@ def test_ls(client: docker.DockerClient, mount_data_tex_dir: Mount):
 
 def test_compile_oneshot(client: docker.DockerClient, mount_data_tex_dir: Mount):
     """一度だけコンパイルすることを確認する"""
-    with run_container(client, IMAGE_NAME, ["-e", "lualatex", "hello"], mounts=[mount_data_tex_dir]) as container:
+    with run_container(
+            client, IMAGE_NAME,
+            ["-e", "lualatex", "hello"], mounts=[mount_data_tex_dir]
+            ) as container:
         result = container.wait()
         logs = container.logs().decode()
 

--- a/tests/test_textlint_ja.py
+++ b/tests/test_textlint_ja.py
@@ -10,7 +10,6 @@ import docker
 from docker.types import Mount
 from pytest import fixture
 
-
 IMAGE_NAME: str = 'docker-images_textlint-ja'
 HOST_PWD: str = os.environ['HOST_PWD']
 
@@ -24,22 +23,24 @@ def client() -> docker.DockerClient:
 @fixture
 def mount_test_dir() -> Mount:
     """testsディレクトリへのマウントを作成する"""
-    return Mount(source=f'{HOST_PWD}/tests', target='/home/node/app', type='bind')
+    return Mount(source=f'{HOST_PWD}/tests',
+                 target='/home/node/app',
+                 type='bind')
 
 
 @fixture
 def mount_data_tex_dir() -> Mount:
     """data/texディレクトリへのマウントを作成する"""
-    return Mount(source=f'{HOST_PWD}/data/tex', target='/home/node/app', type='bind')
+    return Mount(source=f'{HOST_PWD}/data/tex',
+                 target='/home/node/app',
+                 type='bind')
 
 
 @contextmanager
-def run_container(
-        client: docker.DockerClient,
-        image: str,
-        command: Union[list[str], None] = None,
-        **kwargs
-) -> docker.models.containers.Container:
+def run_container(client: docker.DockerClient,
+                  image: str,
+                  command: Union[list[str], None] = None,
+                  **kwargs) -> docker.models.containers.Container:
     """Dockerコンテナを実行する"""
     container = client.containers.run(image, command, detach=True, **kwargs)
     try:
@@ -60,10 +61,10 @@ def test_with_no_input(client: docker.DockerClient):
 
 def test_ls(client: docker.DockerClient, mount_test_dir: Mount):
     """lsコマンドを実行してマウント位置が正しいことを確認する"""
-    with run_container(
-            client, IMAGE_NAME,
-            entrypoint="bash -c 'ls -a'", mounts=[mount_test_dir]
-            ) as container:
+    with run_container(client,
+                       IMAGE_NAME,
+                       entrypoint="bash -c 'ls -a'",
+                       mounts=[mount_test_dir]) as container:
         result = container.wait()
         file_list = container.logs().decode().splitlines()
 
@@ -73,10 +74,10 @@ def test_ls(client: docker.DockerClient, mount_test_dir: Mount):
 
 def test_md_ja(client: docker.DockerClient, mount_test_dir: Mount):
     """Markdownファイルのlintができることを確認する"""
-    with run_container(
-            client, IMAGE_NAME,
-            ['--preset', 'preset-japanese', 'data/ja.md'], mounts=[mount_test_dir]
-            ) as container:
+    with run_container(client,
+                       IMAGE_NAME,
+                       ['--preset', 'preset-japanese', 'data/ja.md'],
+                       mounts=[mount_test_dir]) as container:
         result = container.wait()
         logs = container.logs().decode()
 
@@ -86,7 +87,9 @@ def test_md_ja(client: docker.DockerClient, mount_test_dir: Mount):
 
 def test_latex_ja(client: docker.DockerClient, mount_data_tex_dir: Mount):
     """LaTeXファイルのlintができることを確認する"""
-    with run_container(client, IMAGE_NAME, ['*.tex'], mounts=[mount_data_tex_dir]) as container:
+    with run_container(client,
+                       IMAGE_NAME, ['*.tex'],
+                       mounts=[mount_data_tex_dir]) as container:
         result = container.wait()
         logs = container.logs().decode()
 

--- a/tests/test_textlint_ja.py
+++ b/tests/test_textlint_ja.py
@@ -1,3 +1,7 @@
+"""
+textlint-jaイメージをテストする。
+"""
+
 from contextlib import contextmanager
 import os
 from typing import Union
@@ -13,16 +17,19 @@ HOST_PWD: str = os.environ['HOST_PWD']
 
 @fixture
 def client() -> docker.DockerClient:
+    """Dockerクライアントを作成する"""
     return docker.from_env()
 
 
 @fixture
 def mount_test_dir() -> Mount:
+    """testsディレクトリへのマウントを作成する"""
     return Mount(source=f'{HOST_PWD}/tests', target='/home/node/app', type='bind')
 
 
 @fixture
 def mount_data_tex_dir() -> Mount:
+    """data/texディレクトリへのマウントを作成する"""
     return Mount(source=f'{HOST_PWD}/data/tex', target='/home/node/app', type='bind')
 
 
@@ -33,6 +40,7 @@ def run_container(
         command: Union[list[str], None] = None,
         **kwargs
 ) -> docker.models.containers.Container:
+    """Dockerコンテナを実行する"""
     container = client.containers.run(image, command, detach=True, **kwargs)
     try:
         yield container
@@ -52,7 +60,10 @@ def test_with_no_input(client: docker.DockerClient):
 
 def test_ls(client: docker.DockerClient, mount_test_dir: Mount):
     """lsコマンドを実行してマウント位置が正しいことを確認する"""
-    with run_container(client, IMAGE_NAME, entrypoint="bash -c 'ls -a'", mounts=[mount_test_dir]) as container:
+    with run_container(
+            client, IMAGE_NAME,
+            entrypoint="bash -c 'ls -a'", mounts=[mount_test_dir]
+            ) as container:
         result = container.wait()
         file_list = container.logs().decode().splitlines()
 
@@ -62,7 +73,10 @@ def test_ls(client: docker.DockerClient, mount_test_dir: Mount):
 
 def test_md_ja(client: docker.DockerClient, mount_test_dir: Mount):
     """Markdownファイルのlintができることを確認する"""
-    with run_container(client, IMAGE_NAME, ['--preset', 'preset-japanese', 'data/ja.md'], mounts=[mount_test_dir]) as container:
+    with run_container(
+            client, IMAGE_NAME,
+            ['--preset', 'preset-japanese', 'data/ja.md'], mounts=[mount_test_dir]
+            ) as container:
         result = container.wait()
         logs = container.logs().decode()
 

--- a/tests/test_textlint_ja.py
+++ b/tests/test_textlint_ja.py
@@ -1,32 +1,38 @@
-import os
 from contextlib import contextmanager
+import os
+from typing import Union
 
 import docker
 from docker.types import Mount
 from pytest import fixture
 
 
-IMAGE_NAME='docker-images_textlint-ja'
-HOST_PWD=os.environ['HOST_PWD']
+IMAGE_NAME: str = 'docker-images_textlint-ja'
+HOST_PWD: str = os.environ['HOST_PWD']
 
 
 @fixture
-def client():
+def client() -> docker.DockerClient:
     return docker.from_env()
 
 
 @fixture
-def mount_test_dir():
+def mount_test_dir() -> Mount:
     return Mount(source=f'{HOST_PWD}/tests', target='/home/node/app', type='bind')
 
 
 @fixture
-def mount_data_tex_dir():
+def mount_data_tex_dir() -> Mount:
     return Mount(source=f'{HOST_PWD}/data/tex', target='/home/node/app', type='bind')
 
 
 @contextmanager
-def run_container(client, image, command=None, **kwargs):
+def run_container(
+        client: docker.DockerClient,
+        image: str,
+        command: Union[list[str], None] = None,
+        **kwargs
+) -> docker.models.containers.Container:
     container = client.containers.run(image, command, detach=True, **kwargs)
     try:
         yield container
@@ -34,7 +40,7 @@ def run_container(client, image, command=None, **kwargs):
         container.remove()
 
 
-def test_with_no_input(client):
+def test_with_no_input(client: docker.DockerClient):
     """何も入力を渡さないときに正常に終了することを確認する"""
     with run_container(client, IMAGE_NAME) as container:
         result = container.wait()
@@ -44,16 +50,17 @@ def test_with_no_input(client):
     assert result['StatusCode'] == 0
 
 
-def test_ls(client, mount_test_dir):
+def test_ls(client: docker.DockerClient, mount_test_dir: Mount):
     """lsコマンドを実行してマウント位置が正しいことを確認する"""
     with run_container(client, IMAGE_NAME, entrypoint="bash -c 'ls -a'", mounts=[mount_test_dir]) as container:
         result = container.wait()
         file_list = container.logs().decode().splitlines()
 
     assert 'test_textlint_ja.py' in file_list
+    assert result['StatusCode'] == 0
 
 
-def test_md_ja(client, mount_test_dir):
+def test_md_ja(client: docker.DockerClient, mount_test_dir: Mount):
     """Markdownファイルのlintができることを確認する"""
     with run_container(client, IMAGE_NAME, ['--preset', 'preset-japanese', 'data/ja.md'], mounts=[mount_test_dir]) as container:
         result = container.wait()
@@ -63,9 +70,9 @@ def test_md_ja(client, mount_test_dir):
     assert result['StatusCode'] == 0
 
 
-def test_latex_ja(client, mount_data_tex_dir):
+def test_latex_ja(client: docker.DockerClient, mount_data_tex_dir: Mount):
     """LaTeXファイルのlintができることを確認する"""
-    with run_container(client, IMAGE_NAME, '*.tex', mounts=[mount_data_tex_dir]) as container:
+    with run_container(client, IMAGE_NAME, ['*.tex'], mounts=[mount_data_tex_dir]) as container:
         result = container.wait()
         logs = container.logs().decode()
 


### PR DESCRIPTION
# Summary

type hintを書き加える。
pylintとyapfを追加する。
yapfによるフォーマットを行う。

- refactor: add type hints
- chore: add pylint package to tests image
- docs: add some docstrings to test functions
- chore: add pylint package
- refactor: add yapf to format python test codes
