### PR TITLE
ci: build only cluttex and textlint-ja

### DIFF
--- a/.github/workflows/push-images.yaml
+++ b/.github/workflows/push-images.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: 'Login to ghcr.io'
         run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u horatos --password-stdin
       - name: 'Build images'
-        run: docker compose build
+        run: docker compose build textlint-ja cluttex
       - name: 'Push textlint-ja'
         run: |
           docker tag docker-images_textlint-ja ghcr.io/horatos/textlint-ja:latest


### PR DESCRIPTION
npmのインストールでCIが落ちるのでtestsイメージのビルドをやめる。
