### PR TITLE
ci: change docker image names pushed to ghcr.io

### DIFF
--- a/.github/workflows/push-images.yaml
+++ b/.github/workflows/push-images.yaml
@@ -20,10 +20,10 @@ jobs:
       - name: 'Push textlint-ja'
         run: |
           docker image ls
-          docker tag docker-images_textlint-ja ghcr.io/horatos/textlint-ja:latest
+          docker tag docker-images-textlint-ja ghcr.io/horatos/textlint-ja:latest
           docker push ghcr.io/horatos/textlint-ja:latest
       - name: 'Push cluttex'
         run: |
           docker image ls
-          docker tag docker-images_cluttex ghcr.io/horatos/cluttex:latest
+          docker tag docker-images-cluttex ghcr.io/horatos/cluttex:latest
           docker push ghcr.io/horatos/cluttex:latest


### PR DESCRIPTION
Docker composeのnaming conventionが変更されていたようなので。

https://github.com/horatos/docker-images/runs/7786430326?check_suite_focus=true
